### PR TITLE
Fix TransportTls constructor

### DIFF
--- a/src/transport_tls.rs
+++ b/src/transport_tls.rs
@@ -24,10 +24,11 @@ pub struct TransportTls {
 }
 
 impl TransportTls {
-  /// Constructs a new `TransportTcp`.
+  /// Constructs a new `TransportTls`.
   pub async fn new(addr: &str, connector: TlsConnector) -> io::Result<TransportTls> {
     let tcp_stream = net::TcpStream::connect(addr).await?;
-    let stream = connector.connect(addr, tcp_stream)?.await?;
+    let domain = addr.split(':').next();
+    let stream = connector.connect(domain.unwrap_or(addr), tcp_stream)?.await?;
     Ok(TransportTls {
       stream,
       _addr: addr.to_string(),

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -1,0 +1,16 @@
+#[cfg(test)]
+extern crate speculate;
+#[cfg(test)]
+use speculate::speculate;
+
+use async_std::task;
+
+speculate! {
+    describe "TransportTls" {
+        it "should be able to connect to github.com:443" {
+            task::block_on(async {
+                assert!(cdrs_async::TransportTls::new("github.com:443", Default::default()).await.is_ok());
+            })
+        }
+    }
+}


### PR DESCRIPTION
When constructing `TransportTls` with `TransportTls::new("xxx:9042", ...)` it retrurns `Err` since
in `TransportTls` constructor, `TlsConnector`'s `connect` tries to use `addr` but it contains ":", which is not valid char in domain name.

This PR extracts only the domain name part (before ':') and pass it to `TlsConnector.connect`.

(You may discard the test as I created it for demonstration.)